### PR TITLE
Refactor: Create zonal statistics

### DIFF
--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -36,8 +36,7 @@ def process_masked_raster(
         shp_path: Path = Path(f"{ROOT_DIR}/data/adm2/wca_admbnda_adm2_ocha.shp"),
         ) -> None:
 
-    shapefile = get_shapefile(shp_path=shp_path, 
-                              cols_to_drop= ['OBJECTID_1', 'Shape_Leng', 'Shape_Area', 'validOn', 'validTo', 'last_modif', 'source', 'date'])
+    shapefile = get_shapefile(shp_path=shp_path)
     masked_raster, profile = mask_raster_with_shp(raster_location=raw_raster_location,
                                          gdf=shapefile,
                                          )

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -53,6 +53,7 @@ def process_zonal_statistics(
     shapefile = get_shapefile(shp_path=shp_path)
     zonal_stats = calculate_zonal_statistics(raster_location=raster_location,
                                              shapefile=shapefile)
+    zonal_stats.to_csv(out_path, encoding='utf-8', index=False)
     
 
 # TODO: add overwrite that will replace the existing file if needed

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -205,6 +205,7 @@ def calculate_zonal_statistics(raster_location: Path,
         column_name = f"{stat}_value_kelvin"
         shapefile[column_name] = [result[stat] for result in results]
     
+    shapefile.drop(columns=['geometry'], inplace=True)
 
     return shapefile
 

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -120,7 +120,7 @@ def _lower_case_cols(df: Union[pd.DataFrame, gpd.GeoDataFrame]) -> Union[pd.Data
     return df
     
 
-def mask_raster_with_shp(raster_location: Path, gdf: gpd.GeoDataFrame, nodata: int = 0) -> Tuple[np.ndarray, Profile]:
+def mask_raster_with_shp(raster_location: Path, gdf: gpd.GeoDataFrame) -> Tuple[np.ndarray, Profile]:
     """Masks raster with geodataframe
 
     Args:

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -133,15 +133,25 @@ def mask_raster_with_shp(raster_location: Path, gdf: gpd.GeoDataFrame, nodata: i
 
     with rasterio.open(raster_location, "r") as src:
         profile = src.profile
-
-        # Check if CRSs match between vector and raster
-        if src.crs != gdf.crs:
-            gdf = gdf.to_crs(src.crs)
+        gdf = _check_crs(raster=src, vector=gdf)
 
         masked_raster, _ = mask.mask(dataset=src, shapes=gdf.geometry, crop=True)
     
     return masked_raster, profile
-    
+
+def _check_crs(raster: rasterio.DatasetReader, vector: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Transform CRS of vector if CRS does not match raster
+
+    Args:
+        raster (rasterio.DatasetReader): Raster dataset reader
+        vector (gpd.GeoDataFrame): Geodataframe to be mofidied if needed
+
+    Returns:
+        gpd.GeoDataFrame: _description_
+    """
+    if raster.crs != vector.crs:
+        vector = vector.to_crs(raster.crs)
+    return vector
 
 def kelvin_to_celcius(
         df: pd.DataFrame

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -77,7 +77,10 @@ def write_local_raster(raster: np.ndarray, profile: Profile, out_path: Path) -> 
         dest.write(raster)
 
 
-def get_shapefile(shp_path: Path, cols_to_drop: list[str], lower_case: bool = True) -> gpd.GeoDataFrame:
+def get_shapefile(shp_path: Path,
+                  cols_to_drop: list[str] = ['OBJECTID_1', 'Shape_Leng', 'Shape_Area', 'validOn', 'validTo', 'last_modif', 'source', 'date'],
+                  lower_case: bool = True
+                  ) -> gpd.GeoDataFrame:
     """Get a clean version of the shapefile for 
 
     Args:
@@ -93,7 +96,7 @@ def get_shapefile(shp_path: Path, cols_to_drop: list[str], lower_case: bool = Tr
     else:
         clean_shapefile = shapefile
 
-    return clean_shapefile
+    return gpd.GeoDataFrame(clean_shapefile)
 
 
 def _drop_shapefile_cols(shapefile: gpd.GeoDataFrame,
@@ -101,7 +104,7 @@ def _drop_shapefile_cols(shapefile: gpd.GeoDataFrame,
                          ) -> gpd.GeoDataFrame:
     
     clean_shapefile = shapefile.drop(columns=cols_to_drop)
-    return clean_shapefile
+    return gpd.GeoDataFrame(clean_shapefile)
 
 
 def _lower_case_cols(df: Union[pd.DataFrame, gpd.GeoDataFrame]) -> Union[pd.DataFrame, gpd.GeoDataFrame]:

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -186,10 +186,6 @@ def calculate_zonal_statistics(raster_location: Path,
     """Calculates zonal statistics based on provided list of desired statistics
 
     Args:
-    with rasterio.open(raster, "r", shapefile) as src:
-        array = src.read(1)
-        affine = src.transform
-        nodata = src.nodata
         raster_location (Path): Path to raster. By providing path, zonal_stats function can access the profile directly
         shapefile (gpd.GeoDataFrame): Shapefile that will be the unit of analysis for zonal stats
         provided_stats (str, optional): Statistics to calculate. Defaults to "min mean max".
@@ -205,6 +201,7 @@ def calculate_zonal_statistics(raster_location: Path,
     Returns:
         pd.DataFrame: Tabular results, where each row is a geometry in the shapefile
     """
+    raster_location = _check_tif_extension(raster_location)
 
     return df
 

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -46,7 +46,7 @@ def read_raster(location: Union[str, Path]) -> Tuple[np.ndarray, Profile]:
     return raster, profile
 
 
-def _check_tif_extension(location: Union[str, Path]) -> Union[str, Path]:
+def _check_tif_extension(location: Union[str, Path]) -> Path:
     """Adds .tif to raster location if it is not available
 
     Args:
@@ -55,12 +55,12 @@ def _check_tif_extension(location: Union[str, Path]) -> Union[str, Path]:
     Returns:
         Union[str, Path]: The modified location of the raster (if applicable)
     """
-    if isinstance(location, Path) and not location.suffix == ".tif":
+    if isinstance(location, str):
+        location = Path(location)
+    
+    if not location.suffix == ".tif":
         location = location.with_suffix(".tif")
-    
-    if isinstance(location, str) and not location.endswith(".tif"):
-        location = os.path.join(location + ".tif")
-    
+
     return location
     
 

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -191,17 +191,15 @@ def calculate_zonal_statistics(raster_location: Path,
         provided_stats (str, optional): Statistics to calculate. Defaults to "min mean max".
 
         results = zonal_stats(shapefile,
-                            array,
-                            affine=affine,
-                            nodata=nodata,
-                            stats="min mean max median",
-                            geojson_out=False)
-
-    df = pd.DataFrame(results)
     Returns:
         pd.DataFrame: Tabular results, where each row is a geometry in the shapefile
     """
     raster_location = _check_tif_extension(raster_location)
+    results = zonal_stats(vectors=shapefile.geometry,
+                            raster=raster_location,
+                            nodata=-999,
+                            stats=provided_stats)
+    
 
     return df
 

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -179,17 +179,20 @@ def attribute_join(shapefile: gpd.GeoDataFrame,
     return joined_df
 
 
-def calculate_zonal_statistics(raster: np.ndarray, shapefile) -> pd.DataFrame:
-    """Write zonal statistics to local directory
+def calculate_zonal_statistics(raster_location: Path,
+                               shapefile: gpd.GeoDataFrame,
+                               provided_stats: str = "min mean max"
+                               ) -> pd.DataFrame:
+    """Calculates zonal statistics based on provided list of desired statistics
 
     Args:
-        shp_path (str): Path to shapefile
-    """
-
     with rasterio.open(raster, "r", shapefile) as src:
         array = src.read(1)
         affine = src.transform
         nodata = src.nodata
+        raster_location (Path): Path to raster. By providing path, zonal_stats function can access the profile directly
+        shapefile (gpd.GeoDataFrame): Shapefile that will be the unit of analysis for zonal stats
+        provided_stats (str, optional): Statistics to calculate. Defaults to "min mean max".
 
         results = zonal_stats(shapefile,
                             array,
@@ -199,6 +202,9 @@ def calculate_zonal_statistics(raster: np.ndarray, shapefile) -> pd.DataFrame:
                             geojson_out=False)
 
     df = pd.DataFrame(results)
+    Returns:
+        pd.DataFrame: Tabular results, where each row is a geometry in the shapefile
+    """
 
     return df
 

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -200,8 +200,13 @@ def calculate_zonal_statistics(raster_location: Path,
                             nodata=-999,
                             stats=provided_stats)
     
+    stats_list= provided_stats.split(" ")
+    for stat in stats_list:
+        column_name = f"{stat}_value_kelvin"
+        shapefile[column_name] = [result[stat] for result in results]
+    
 
-    return df
+    return shapefile
 
 
 def climatology_yearly_table_generator(

--- a/pipeline/processing_functions.py
+++ b/pipeline/processing_functions.py
@@ -170,10 +170,11 @@ def kelvin_to_celcius(
     
     return col - 273.15
 
-def attribute_join(shapefile, df: pd.DataFrame, method: str = "left") -> pd.DataFrame:
+def attribute_join(shapefile: gpd.GeoDataFrame,
+                   df: pd.DataFrame,
+                   ) -> pd.DataFrame:
     
-    #Attribute join between shapefile and zonal stats
-    joined_df = shapefile.join(df, how=method)
+    joined_df = df.join(shapefile)
      
     return joined_df
 

--- a/pipeline/processing_steps.py
+++ b/pipeline/processing_steps.py
@@ -43,7 +43,7 @@ def get_processing_steps(product: ChelsaProduct, scenario: Scenario, month: Mont
     if not os.path.exists(masked_file_path):
         processing_steps.append(RasterProcessingStep.MASK)
     
-    zonal_file_path = Path(os.path.join(zonal_path[0], f"{scenario.value}_{month.value}.tif"))
+    zonal_file_path = Path(os.path.join(zonal_path[0], f"{scenario.value}_{month.value}.csv"))
     if not os.path.exists(zonal_file_path):
         processing_steps.append(RasterProcessingStep.ZONAL_STATISTICS)
     


### PR DESCRIPTION
# Changes

This is part 3 of the refactoring pipeline process to allow for any available product, scenario, and month

* Refactors creating and exporting zonal statistics. Function is only triggered if it is a processing step for a given product, scenario, and month. 
* `create_zonal_statistics` supports geodataframes and creates columns in gdf based on user provided statistics
* Quality of life improvements, such as extracting a `_check_crs` function and preventing typing errors by clarifying inputs and outputs