### PR TITLE
Refactor/post initializer pathways

### DIFF
--- a/pipeline/climatology.py
+++ b/pipeline/climatology.py
@@ -50,6 +50,14 @@ class Month(Enum):
     DECEMBER = 12
 
 
+class TemperatureProduct(Enum):
+    """Convenience class to identify temperature products"""
+
+    Temperature = auto()
+    MinimumTemperature = auto()
+    MaximumTemperature = auto()
+
+
 class ChelsaProduct(ABC):
     """Abstract class for all CHELSA Product products"""
 
@@ -208,13 +216,6 @@ class MinimumTemperature(ChelsaProduct):
     months = [month for month in Month]
     base_url = "tasmin"
 
-
-class TemperatureProduct(Enum):
-    """Convenience class to identify temperature products"""
-
-    Temperature = auto()
-    MinimumTemperature = auto()
-    MaximumTemperature = auto()
 
 
 def get_climatology(product: str) -> ChelsaProduct:

--- a/pipeline/climatology.py
+++ b/pipeline/climatology.py
@@ -65,10 +65,15 @@ class ChelsaProduct(ABC):
 
     base_url: str = field(init=False)
     product: Product = field(init=False)
+    scenario: Scenario
+    month: Month
     available_scenarios: list[Scenario] = field(init=False)
     available_months: list[Month] = field(init=False)
     phase: Phase = Phase.CMIP5
     time_period: str = "2061-2080"
+
+    def __post_init__(self):
+        self._set_pathways_as_attributes()
 
     def get_url(self, scenario: Scenario, month: Month) -> str:
         """Constructs a URL based on a given scenario and month for a given product.
@@ -159,6 +164,9 @@ class Temperature(ChelsaProduct):
     available_months = [month for month in Month]
     base_url = "tas"
 
+    def __post_init__(self):
+        super(Temperature, self).__post_init__()
+
 
 @dataclass
 class Bio(ChelsaProduct):
@@ -174,6 +182,9 @@ class Bio(ChelsaProduct):
     ]
     available_months = [month for month in Month]
     base_url = "bio"
+
+    def __post_init__(self):
+        super(Bio, self).__post_init__()
 
 
 @dataclass
@@ -191,6 +202,8 @@ class Precipitation(ChelsaProduct):
     available_months = [month for month in Month]
     base_url = "pr"
 
+    def __post_init__(self):
+        super(Precipitation, self).__post_init__()
 
 
 @dataclass
@@ -208,6 +221,9 @@ class MaximumTemperature(ChelsaProduct):
     available_months = [month for month in Month]
     base_url = "tasmax"
 
+    def __post_init__(self):
+        super(MaximumTemperature, self).__post_init__()
+
 
 @dataclass
 class MinimumTemperature(ChelsaProduct):
@@ -224,6 +240,8 @@ class MinimumTemperature(ChelsaProduct):
     available_months = [month for month in Month]
     base_url = "tasmin"
 
+    def __post_init__(self):
+        super(MinimumTemperature, self).__post_init__()
 
 
 def get_climatology(

--- a/pipeline/climatology.py
+++ b/pipeline/climatology.py
@@ -61,12 +61,12 @@ class TemperatureProduct(Enum):
 class ChelsaProduct(ABC):
     """Abstract class for all CHELSA Product products"""
 
+    available_scenarios: list[Scenario] = field(init=False)
+    available_months: list[Month] = field(init=False)
     phase: Phase = Phase.CMIP5
     time_period: str = "2061-2080"
     base_url: str
     product: Product
-    scenarios: list[Scenario]
-    months: list[Month]
 
     def get_url(self, scenario: Scenario, month: Month) -> str:
         """Constructs a URL based on a given scenario and month for a given product.
@@ -74,16 +74,16 @@ class ChelsaProduct(ABC):
         Returns:
             download_url: URL that can be used to download raster .tif file
         """
-        if scenario not in self.scenarios:
+        if scenario not in self.available_scenarios:
             raise ValueError(
                 f"This product is not available. \
-                         Options include {self.scenarios}"
+                         Options include {self.available_scenarios}"
             )
 
-        if month not in self.months:
+        if month not in self.available_months:
             raise ValueError(
                 f"This month is not available. \
-                         Options include {self.months}"
+                         Options include {self.available_months}"
             )
 
         download_url = f"https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V1/{self.phase.value}/{self.time_period}/{self.product.value}/CHELSA_{self.base_url}_mon_{scenario.value}_r1i1p1_g025.nc_{month.value}_{self.time_period}_V1.2.tif"
@@ -146,14 +146,14 @@ class Temperature(ChelsaProduct):
     """Concrete implementation of temperature ChelsaProduct"""
 
     product = Product.TEMP
-    scenarios = [
+    available_scenarios = [
         Scenario.ACCESS1_0_rcp45,
         Scenario.ACCESS1_0_rcp85,
         Scenario.BNU_ESM_rcp26,
         Scenario.BNU_ESM_rcp45,
         Scenario.CCSM4_rcp60,
     ]
-    months = [month for month in Month]
+    available_months = [month for month in Month]
     base_url = "tas"
 
 
@@ -161,14 +161,14 @@ class Bio(ChelsaProduct):
     """Concrete implementation of bio ChelsaProduct"""
 
     product = Product.BIO
-    scenarios = [
+    available_scenarios = [
         Scenario.ACCESS1_0_rcp45,
         Scenario.ACCESS1_0_rcp85,
         Scenario.BNU_ESM_rcp26,
         Scenario.BNU_ESM_rcp45,
         Scenario.CCSM4_rcp60,
     ]
-    months = [month for month in Month]
+    available_months = [month for month in Month]
     base_url = "bio"
 
 
@@ -176,14 +176,14 @@ class Precipitation(ChelsaProduct):
     """Concrete implementation of precipitation ChelsaProduct"""
 
     product = Product.PREC
-    scenarios = [
+    available_scenarios = [
         Scenario.ACCESS1_0_rcp45,
         Scenario.ACCESS1_0_rcp85,
         Scenario.BNU_ESM_rcp26,
         Scenario.BNU_ESM_rcp45,
         Scenario.CCSM4_rcp60,
     ]
-    months = [month for month in Month]
+    available_months = [month for month in Month]
     base_url = "pr"
 
 
@@ -191,14 +191,14 @@ class MaximumTemperature(ChelsaProduct):
     """Concrete implementation of maxiumum temperature ChelsaProduct"""
 
     product = Product.TMAX
-    scenarios = [
+    available_scenarios = [
         Scenario.ACCESS1_0_rcp45,
         Scenario.ACCESS1_0_rcp85,
         Scenario.BNU_ESM_rcp26,
         Scenario.BNU_ESM_rcp45,
         Scenario.CCSM4_rcp60,
     ]
-    months = [month for month in Month]
+    available_months = [month for month in Month]
     base_url = "tasmax"
 
 
@@ -206,14 +206,14 @@ class MinimumTemperature(ChelsaProduct):
     """Concrete implementation of minimum temperature ChelsaProduct"""
 
     product = Product.TMIN
-    scenarios = [
+    available_scenarios = [
         Scenario.ACCESS1_0_rcp45,
         Scenario.ACCESS1_0_rcp85,
         Scenario.BNU_ESM_rcp26,
         Scenario.BNU_ESM_rcp45,
         Scenario.CCSM4_rcp60,
     ]
-    months = [month for month in Month]
+    available_months = [month for month in Month]
     base_url = "tasmin"
 
 

--- a/pipeline/climatology.py
+++ b/pipeline/climatology.py
@@ -1,5 +1,6 @@
 import os
 from abc import ABC
+from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
 
@@ -58,15 +59,16 @@ class TemperatureProduct(Enum):
     MaximumTemperature = auto()
 
 
+@dataclass
 class ChelsaProduct(ABC):
     """Abstract class for all CHELSA Product products"""
 
+    base_url: str = field(init=False)
+    product: Product = field(init=False)
     available_scenarios: list[Scenario] = field(init=False)
     available_months: list[Month] = field(init=False)
     phase: Phase = Phase.CMIP5
     time_period: str = "2061-2080"
-    base_url: str
-    product: Product
 
     def get_url(self, scenario: Scenario, month: Month) -> str:
         """Constructs a URL based on a given scenario and month for a given product.
@@ -142,6 +144,7 @@ class ChelsaProduct(ABC):
                 os.makedirs(path, exist_ok=True)
 
 
+@dataclass
 class Temperature(ChelsaProduct):
     """Concrete implementation of temperature ChelsaProduct"""
 
@@ -157,6 +160,7 @@ class Temperature(ChelsaProduct):
     base_url = "tas"
 
 
+@dataclass
 class Bio(ChelsaProduct):
     """Concrete implementation of bio ChelsaProduct"""
 
@@ -172,6 +176,7 @@ class Bio(ChelsaProduct):
     base_url = "bio"
 
 
+@dataclass
 class Precipitation(ChelsaProduct):
     """Concrete implementation of precipitation ChelsaProduct"""
 
@@ -187,6 +192,8 @@ class Precipitation(ChelsaProduct):
     base_url = "pr"
 
 
+
+@dataclass
 class MaximumTemperature(ChelsaProduct):
     """Concrete implementation of maxiumum temperature ChelsaProduct"""
 
@@ -202,6 +209,7 @@ class MaximumTemperature(ChelsaProduct):
     base_url = "tasmax"
 
 
+@dataclass
 class MinimumTemperature(ChelsaProduct):
     """Concrete implementation of minimum temperature ChelsaProduct"""
 
@@ -218,7 +226,9 @@ class MinimumTemperature(ChelsaProduct):
 
 
 
-def get_climatology(product: str) -> ChelsaProduct:
+def get_climatology(
+    product: Product, scenario: Scenario, month: Month
+) -> ChelsaProduct:
     """Returns concrete implementation based on user provided product
 
     Args:
@@ -236,11 +246,11 @@ def get_climatology(product: str) -> ChelsaProduct:
         )
 
     factories = {
-        "temp": Temperature(),
-        "bio": Bio(),
-        "prec": Precipitation(),
-        "tmax": MaximumTemperature(),
-        "tmin": MinimumTemperature(),
+        "temp": Temperature(scenario=scenario, month=month),
+        "bio": Bio(scenario=scenario, month=month),
+        "prec": Precipitation(scenario=scenario, month=month),
+        "tmax": MaximumTemperature(scenario=scenario, month=month),
+        "tmin": MinimumTemperature(scenario=scenario, month=month),
     }
 
     return factories[lower_case_product]

--- a/pipeline/climatology.py
+++ b/pipeline/climatology.py
@@ -91,7 +91,7 @@ class ChelsaProduct(ABC):
         download_url = f"https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V1/{self.phase.value}/{self.time_period}/{self.product.value}/CHELSA_{self.base_url}_mon_{scenario.value}_r1i1p1_g025.nc_{month.value}_{self.time_period}_V1.2.tif"
         return download_url
 
-    def set_pathways_as_attributes(self, scenario: Scenario, month: Month):
+    def _set_pathways_as_attributes(self) -> None:
         """Generate directories and file paths as class attributes
         Used to determine if files are already available, or should
         be processed by pipeline
@@ -106,7 +106,7 @@ class ChelsaProduct(ABC):
         config = read_config("config.json")
 
         base_path = Path(
-            f"{config.root_dir}/{self.phase.value}/{self.product.value}/{scenario.value}/"
+            f"{config.root_dir}/{self.phase.value}/{self.product.value}/{self.scenario.value}/"
         )
 
         self.raw_raster_dir = Path(f"{base_path}/{config.raw_raster_dir}/")
@@ -115,16 +115,16 @@ class ChelsaProduct(ABC):
         self.yearly_aggregate_dir = Path(f"{base_path}/{config.yearly_aggregate_dir}/")
 
         self.raw_raster_path = Path(
-            f"{self.raw_raster_dir}/{scenario.value}_{month.value}.tif"
+            f"{self.raw_raster_dir}/{self.scenario.value}_{self.month.value}.tif"
         )
         self.cropped_raster_path = Path(
-            f"{self.cropped_raster_dir}/{scenario.value}_{month.value}.tif"
+            f"{self.cropped_raster_dir}/{self.scenario.value}_{self.month.value}.tif"
         )
         self.zonal_file_path = Path(
-            f"{self.zonal_stats_dir}/{scenario.value}_{month.value}.csv"
+            f"{self.zonal_stats_dir}/{self.scenario.value}_{self.month.value}.csv"
         )
         self.yearly_aggregate_path = Path(
-            f"{self.yearly_aggregate_dir}/{scenario.value}_{month.value}_yearly.csv"
+            f"{self.yearly_aggregate_dir}/{self.scenario.value}_{self.month.value}_yearly.csv"
         )
 
         directories = [

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -9,7 +9,7 @@ config = read_config("config.json")
 logger = setup_logger()
 
 
-def run_single_month(product: str, scenario: Scenario, month: Month):
+def run_single_month(product: Product, scenario: Scenario, month: Month):
     """Runs pipeline given a product, scenario, and month.
     Steps include downloading, cropping, zonal statistics, uploading to the database.
     If all 12 months for a scenario are available, a yearly aggregate is generated.
@@ -41,7 +41,7 @@ def run_single_month(product: str, scenario: Scenario, month: Month):
     )
 
 
-def run_all_months(product: str, scenario: Scenario):
+def run_all_months(product: Product, scenario: Scenario):
     """All months for a given product's scenario"""
     available_months = [month for month in Month]
 
@@ -52,7 +52,7 @@ def run_all_months(product: str, scenario: Scenario):
 
 
 if __name__ == "__main__":
-    raster_processing_flow(
+    run_single_month(
         product=Product[config.product],
         scenario=Scenario[config.scenario],
         month=Month[config.month],

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -24,9 +24,7 @@ def run_single_month(product: Product, scenario: Scenario, month: Month):
     chelsa_product = get_climatology(product=product, scenario=scenario, month=month)
 
     # Determine which processing steps are needed for product's scenario
-    processing_steps = get_processing_steps(
-        product=chelsa_product, scenario=scenario, month=month
-    )
+    processing_steps = get_processing_steps(chelsa_product=chelsa_product)
     processing_step_names = [step.name for step in processing_steps]
 
     logger.info(
@@ -34,10 +32,7 @@ def run_single_month(product: Product, scenario: Scenario, month: Month):
     )
 
     execute_processing_steps(
-        processing_steps=processing_steps,
-        chelsa_product=chelsa_product,
-        scenario=scenario,
-        month=month,
+        processing_steps=processing_steps, chelsa_product=chelsa_product
     )
 
 

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -21,7 +21,7 @@ def run_single_month(product: Product, scenario: Scenario, month: Month):
     """
 
     # Return concrete implementation of climatology object
-    chelsa_product = get_climatology(product=product)
+    chelsa_product = get_climatology(product=product, scenario=scenario, month=month)
 
     # Determine which processing steps are needed for product's scenario
     processing_steps = get_processing_steps(

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -22,7 +22,6 @@ def run_single_month(product: str, scenario: Scenario, month: Month):
 
     # Return concrete implementation of climatology object
     chelsa_product = get_climatology(product=product)
-    chelsa_product.set_pathways_as_attributes(scenario=scenario, month=month)
 
     # Determine which processing steps are needed for product's scenario
     processing_steps = get_processing_steps(

--- a/pipeline/processing_steps.py
+++ b/pipeline/processing_steps.py
@@ -33,19 +33,21 @@ def get_processing_steps(chelsa_product: ChelsaProduct) -> list[RasterProcessing
 
     processing_steps = []
 
-    if not os.path.exists(product.raw_raster_path):
+    if not os.path.exists(chelsa_product.raw_raster_path):
         processing_steps.append(RasterProcessingStep.DOWNLOAD)
 
-    if not os.path.exists(product.cropped_raster_path):
+    if not os.path.exists(chelsa_product.cropped_raster_path):
         processing_steps.append(RasterProcessingStep.MASK)
 
-    if not os.path.exists(product.zonal_file_path):
+    if not os.path.exists(chelsa_product.zonal_file_path):
         processing_steps.append(RasterProcessingStep.ZONAL_STATISTICS)
 
     all_months_available = _check_monthly_zonal_stats_complete(
-        zonal_path=Path(product.zonal_stats_dir)
+        zonal_path=Path(chelsa_product.zonal_stats_dir)
     )
-    if all_months_available and not os.path.exists(product.yearly_aggregate_path):
+    if all_months_available and not os.path.exists(
+        chelsa_product.yearly_aggregate_path
+    ):
         processing_steps.append(RasterProcessingStep.YEARLY_TABLE)
 
     # table_exists = _check_if_table_exists(table_name=f"{scenario}_{month}")

--- a/pipeline/processing_steps.py
+++ b/pipeline/processing_steps.py
@@ -85,6 +85,7 @@ def execute_processing_steps(
         month (Month): Month to be processed
     """
     if RasterProcessingStep.DOWNLOAD in processing_steps:
+        logger.info("Starting raster download")
         process_raw_raster(
             product=chelsa_product,
             scenario=chelsa_product.scenario,
@@ -92,13 +93,18 @@ def execute_processing_steps(
             raw_out_path=chelsa_product.raw_raster_path,
         )
 
+        logger.info("Finished raster download")
+
     if RasterProcessingStep.MASK in processing_steps:
+        logger.info("Starting raster cropping")
         process_masked_raster(
             raw_raster_location=chelsa_product.raw_raster_path,
             masked_out_path=chelsa_product.cropped_raster_path,
         )
+        logger.info("Finished raster cropping")
 
     if RasterProcessingStep.ZONAL_STATISTICS in processing_steps:
+        logger.info("Starting zonal statistics")
         process_zonal_statistics(
             raster_location=chelsa_product.cropped_raster_path,
             out_path=chelsa_product.zonal_file_path,
@@ -107,20 +113,25 @@ def execute_processing_steps(
             month=chelsa_product.month,
             place_id=config.adm_unique_id,
         )
+        logger.info("Finished zonal statistics")
 
     if RasterProcessingStep.YEARLY_TABLE in processing_steps:
+        logger.info("Starting yearly table")
         process_yearly_table(
             product=chelsa_product,
             zonal_dir=chelsa_product.zonal_stats_dir,
             out_path=chelsa_product.yearly_aggregate_path,
             sort_values=[config.adm_unique_id, "month"],
         )
+        logger.info("Finished yearly ")
 
     if RasterProcessingStep.UPLOAD in processing_steps:
+        logger.info("Starting DB upload")
         upload_to_db(
             df_path=chelsa_product.zonal_file_path,
             table_name=chelsa_product.product.value,
         )
+        logger.info("Finished DB upload")
 
     if len(processing_steps) == 0:
         logger.info(

--- a/pipeline/processing_steps.py
+++ b/pipeline/processing_steps.py
@@ -2,7 +2,7 @@ import os
 from enum import Enum, auto
 from pathlib import Path
 
-from climatology import ChelsaProduct, Month, Product, Scenario
+from climatology import ChelsaProduct
 from config import read_config
 from crop import process_masked_raster
 from download import process_raw_raster
@@ -24,9 +24,7 @@ class RasterProcessingStep(Enum):
     UPLOAD = auto()
 
 
-def get_processing_steps(
-    product: ChelsaProduct, scenario: Scenario, month: Month
-) -> list[RasterProcessingStep]:
+def get_processing_steps(chelsa_product: ChelsaProduct) -> list[RasterProcessingStep]:
     """Determine which processing steps are needed for a given month of the product's scenario.
     Each pipeline run is for a specific product, month, and scenario pair.
 
@@ -74,10 +72,7 @@ def _check_monthly_zonal_stats_complete(zonal_path: Path) -> bool:
 
 
 def execute_processing_steps(
-    processing_steps: list[RasterProcessingStep],
-    chelsa_product: ChelsaProduct,
-    scenario: Scenario,
-    month: Month,
+    processing_steps: list[RasterProcessingStep], chelsa_product: ChelsaProduct
 ) -> None:
     """Execute downloads, cropping, zonal statistics, and yearly table depending on processing steps
 
@@ -90,8 +85,8 @@ def execute_processing_steps(
     if RasterProcessingStep.DOWNLOAD in processing_steps:
         process_raw_raster(
             product=chelsa_product,
-            scenario=scenario,
-            month=month,
+            scenario=chelsa_product.scenario,
+            month=chelsa_product.month,
             raw_out_path=chelsa_product.raw_raster_path,
         )
 
@@ -106,8 +101,8 @@ def execute_processing_steps(
             raster_location=chelsa_product.cropped_raster_path,
             out_path=chelsa_product.zonal_file_path,
             product=chelsa_product,
-            scenario=scenario,
-            month=month,
+            scenario=chelsa_product.scenario,
+            month=chelsa_product.month,
             place_id=config.adm_unique_id,
         )
 
@@ -127,5 +122,5 @@ def execute_processing_steps(
 
     if len(processing_steps) == 0:
         logger.info(
-            f"All available steps already completed for {chelsa_product}_{scenario.name}_{month.name}"
+            f"All available steps already completed for {chelsa_product}_{chelsa_product.scenario.name}_{chelsa_product.month.name}"
         )

--- a/pipeline/processing_steps.py
+++ b/pipeline/processing_steps.py
@@ -3,11 +3,11 @@ from enum import Enum, auto
 from pathlib import Path
 
 from climatology import ChelsaProduct, Month, Product, Scenario
-from climatology_uploads import _check_if_table_exists, upload_to_db
 from config import read_config
 from crop import process_masked_raster
 from download import process_raw_raster
 from log import setup_logger
+from upload import _check_if_table_exists, upload_to_db
 from yearly_table import process_yearly_table
 from zonal_stats import process_zonal_statistics
 

--- a/pipeline/processing_steps.py
+++ b/pipeline/processing_steps.py
@@ -33,8 +33,6 @@ def get_processing_steps(
     TODO: Log pipeline runs on postgres database.
     """
 
-    product.set_pathways_as_attributes(scenario=scenario, month=month)
-
     processing_steps = []
 
     if not os.path.exists(product.raw_raster_path):


### PR DESCRIPTION
# Changes

* Change all product classes to dataclasses to allow for explicit `__post_init__` method to create pathways based on instance variables
* This reduces coupling in the code by requiring only a chelsaproduct instance for most functions in `main.py`, rather than additional and redundant scenario and month variables that had to be passed more than once